### PR TITLE
cd: update NPM token in GitHub Actions workflow

### DIFF
--- a/.github/workflows/fast-forward.yml
+++ b/.github/workflows/fast-forward.yml
@@ -24,4 +24,4 @@ jobs:
           # never post a comment.  (In all cases the information is
           # still available in the step's summary.)
           comment: on-error
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }} ## This allows to trigger push action from within this workflow. Read more - https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
+          GITHUB_TOKEN: ${{ secrets.ASSOCIATION_RELEASE_TOKEN }} ## This allows to trigger push action from within this workflow. Read more - https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
       - name: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.ASSOCIATION_NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.HVSM_NPM_RELEASE_TOKEN }}
         run: |
           cd dist
           yarn --frozen-lockfile


### PR DESCRIPTION
Updates the NPM token secret reference in the GitHub Actions release workflow from ASSOCIATION_NPM_TOKEN to HVSM_NPM_RELEASE_TOKEN. This change ensures the signing-manager-types package uses its dedicated NPM token for releases rather than a generic association token, providing better security isolation and token management for this specific project.